### PR TITLE
docs(input-date): adiciona componente no storybook

### DIFF
--- a/src/components/inputs/date/date.stories.jsx
+++ b/src/components/inputs/date/date.stories.jsx
@@ -1,0 +1,16 @@
+import { InputDate } from '.'
+
+export default {
+  title: 'InputDate',
+  component: InputDate
+}
+
+const Template = args => <InputDate {...args} />
+
+export const Date = Template.bind({})
+
+Date.args = {
+  label: 'Data de Inicio',
+  onChange: () => { },
+  name: 'data-inicio'
+}

--- a/src/components/inputs/text/text.stories.jsx
+++ b/src/components/inputs/text/text.stories.jsx
@@ -1,0 +1,16 @@
+import { InputText } from '.'
+
+export default {
+  title: 'InputText',
+  component: InputText
+}
+
+const Template = args => <InputText {...args} />
+
+export const Text = Template.bind({})
+
+Text.args = {
+  label: 'Texto',
+  onChange: () => { },
+  name: 'Texto'
+}


### PR DESCRIPTION
#39 - Adicionando stories nos componentes input
====
  
### 🆙 CHANGELOG

- Adicionamos o input date e o input text no storybook;  

## ⚠️ Me certifico que:

- [x] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [x] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [x] Solicitei **code review** para 2 pessoas

## ⚠️ Como testar:

Não necessita de testes.
