### PR TITLE
70/bug botão de avaliar perdeu seu estilo na refatoração

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -2,7 +2,12 @@ import styled from 'styled-components'
 
 export const StyledSelectContainer = styled.div`
   display: flex;
+  flex-direction: column;
   justify-content: flex-start;
-  margin-bottom: 5px;
   font-weight: bold;
+  
+  & > label {
+    margin-bottom: 5px;
+  }
+
 `

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -4,4 +4,5 @@ export const StyledSelectContainer = styled.div`
   display: flex;
   justify-content: flex-start;
   margin-bottom: 5px;
+  font-weight: bold;
 `

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -3,11 +3,12 @@ import styled from 'styled-components'
 export const StyledSelectContainer = styled.div`
   display: flex;
   flex-direction: column;
+  margin-bottom: 5px;
   justify-content: flex-start;
   font-weight: bold;
   
   & > label {
-    margin-bottom: 5px;
+    margin-bottom: 8px;
   }
 
 `

--- a/src/pages/evaluation/index.js
+++ b/src/pages/evaluation/index.js
@@ -8,7 +8,7 @@ import { client } from '../../service'
 import { Answer } from './components/answer/answer'
 import { Header } from './components/header/header.js'
 import { Score } from './components/select-note/select-note'
-import { Container, Download, Buttons, Anchor } from './styled'
+import { Container, Download, ContainerButtons, Anchor } from './styled'
 
 const EvaluationChallenge = () => {
   const [exercise, setExercise] = useState(null)
@@ -47,7 +47,7 @@ const EvaluationChallenge = () => {
 
       <Answer exercise={exercise} />
 
-      <Buttons>
+      <ContainerButtons>
 
         <DefaultButton text="Cancelar" onClick={handleCancel} />
         <Modal classe={'primary'} text="Avaliar" title="Avaliação" disabled={disableEvaluationButton} >
@@ -56,7 +56,7 @@ const EvaluationChallenge = () => {
 
         </Modal>
 
-      </Buttons>
+      </ContainerButtons>
 
     </Container >
   )

--- a/src/pages/evaluation/index.js
+++ b/src/pages/evaluation/index.js
@@ -50,7 +50,7 @@ const EvaluationChallenge = () => {
       <Buttons>
 
         <DefaultButton text="Cancelar" onClick={handleCancel} />
-        <Modal classe={'button-primary'} text="Avaliar" title="Avaliação" disabled={disableEvaluationButton} >
+        <Modal classe={'primary'} text="Avaliar" title="Avaliação" disabled={disableEvaluationButton} >
 
           <Score exercise={exercise} />
 

--- a/src/pages/evaluation/styled.js
+++ b/src/pages/evaluation/styled.js
@@ -65,12 +65,12 @@ h2 {
   color: rgb(149, 149, 149);
 }
 `
-export const Buttons = styled.div`
+export const ContainerButtons = styled.div`
   display: flex;
   justify-content: right;
   margin-top: 20px;
   
-  .primary {
+  & > .primary {
     margin-left: 10px;
   }
 `
@@ -78,11 +78,12 @@ export const TypeContainer = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
-
-  Select {
-    margin-right: 10px;
-  }  
+  
+  & > .sucess {
+    margin-left: 10px;
+  }
 `
+
 export const ScoreContainer = styled.div`
   textarea#message-text {
     display: block;

--- a/src/pages/evaluation/styled.js
+++ b/src/pages/evaluation/styled.js
@@ -69,10 +69,19 @@ export const Buttons = styled.div`
   display: flex;
   justify-content: right;
   margin-top: 20px;
+  
+  .primary {
+    margin-left: 10px;
+  }
 `
 export const TypeContainer = styled.div`
   display: flex;
   flex-direction: row;
+  align-items: center;
+
+  Select {
+    margin-right: 10px;
+  }  
 `
 export const ScoreContainer = styled.div`
   textarea#message-text {

--- a/src/pages/evaluation/styled.js
+++ b/src/pages/evaluation/styled.js
@@ -72,7 +72,7 @@ export const Buttons = styled.div`
 `
 export const TypeContainer = styled.div`
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
 `
 export const ScoreContainer = styled.div`
   textarea#message-text {


### PR DESCRIPTION
#70  - bug botão de avaliar perdeu seu estilo na refatoração
====
  
### 🆙 CHANGELOG

- Correção do estilo do tipo/select da página de avaliação
- Adição de espaçamento entre botões da tela de avaliação (e somente nessa tela, visto que nas outras páginas os botões não deveriam ser alterados) 

## ⚠️ Me certifico que:

- [x] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [x] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [x] Solicitei **code review** para 2 pessoas
- [ ] Solicitei **QA** para 2 pessoas
- [ ] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:
- [x] Entrar no link de ambiente de teste: https://esther-acelera-mais.herokuapp.com/
- [x] Logar na aplicação (email: ju@gmail.com, senha: 123456)
- [x] Acessar algum dos processos seletivos e clicar em algum exercício que não tenha sido corrigido
- [x] Verificar se a tela de avaliação está com o seguinte estilo (_**atentar se existe espaçamento entre elementos**_, se não estão "grudados")
![image](https://user-images.githubusercontent.com/64702147/150543947-d1cc5ad2-28f3-4bb0-9c94-c2c069241f38.png)

- [x] Ao clicar na opção para selecionar um tipo de exercício, verificar se a tela está como na imagem abaixo: 
![image](https://user-images.githubusercontent.com/64702147/150544232-e9652b57-255f-44cf-bd91-e48717075bb8.png)

- [x]  Ao finalizar a escolha do tipo do exercício, a tela deverá estar assim:
![image](https://user-images.githubusercontent.com/64702147/150545174-a1ef06eb-10ce-4348-b9a0-ae9131c1ee61.png)

- [x] Aplicação não deve conter nenhum erro, warning ou console.log
- [x] Alteração proposta no card foi implementada
