### PR TITLE
64/implementar pagina de exercicios i18n

### DIFF
--- a/src/components/status/index.js
+++ b/src/components/status/index.js
@@ -4,21 +4,21 @@ import { useTranslation } from 'react-i18next'
 
 export const Status = ({
   status, options = {
-    opened: 'Aberto',
-    closed: 'Fechado',
-    prepairing: 'Em preparação'
+    opened: 'status.opened',
+    closed: 'status.closed',
+    preparing: 'status.preparing'
   }
 }) => {
   const { t } = useTranslation()
 
-  let label = t('status.closed')
+  let label = t(options.closed)
 
   if (status === 'status-opened') {
-    label = t('status.open')
+    label = t(options.opened)
   }
 
   if (status === 'status-preparing') {
-    label = t('status.preparing')
+    label = t(options.preparing)
   }
   return (
     <StyledSpan className={status}>{label}</StyledSpan>

--- a/src/pages/exercises/components/toggle-row/index.js
+++ b/src/pages/exercises/components/toggle-row/index.js
@@ -6,6 +6,7 @@ import { Status } from '../../../../components/status'
 import { client } from '../../../../service'
 import { useNavigate } from 'react-router-dom'
 import { Tr } from './styled'
+import { useTranslation } from 'react-i18next'
 
 const statusEnum = {
   PREPARING: 'status-preparing',
@@ -47,6 +48,7 @@ const isPreparing = ({ status }, mentorName, mentorNameLocal) => {
 }
 
 export const ToggleRow = ({ item }) => {
+  const { t } = useTranslation()
   const [checked, setChecked] = useState(false)
   const navigate = useNavigate()
   const [mentorNameLocal] = useState(localStorage.getItem('mentorName'))
@@ -68,7 +70,7 @@ export const ToggleRow = ({ item }) => {
     <>
       <Tr>
         <td>{item.exercise}</td>
-        <td>{item.type ? item.type : 'Não definido'}</td>
+        <td>{item.type ? item.type : t('exercise.toggle-row.type')}</td>
         <td className='options' colSpan='2'>
           {!isOpened(item)
             ? <Status
@@ -80,7 +82,7 @@ export const ToggleRow = ({ item }) => {
               }} />
             : null}
           <ActionButton
-            text={'Avaliar'}
+            text={t('exercise.toggle-row.evaluate')}
             icon={faPen}
             disabled={isClosed({ status: getStatus(item) }) || isPreparing({ status: getStatus(item) }, item.evaluation.mentorName, mentorNameLocal)}
             onClick={handleSubmit} />

--- a/src/pages/exercises/components/toggle-row/index.js
+++ b/src/pages/exercises/components/toggle-row/index.js
@@ -25,24 +25,13 @@ const getStatus = (item) => {
 
 const isPrepared = ({ status }) => status === statusEnum.PREPARING
 
-const isClosedOrPreparing = ({ status }) => {
-  if (status === statusEnum.PREPARING || status === statusEnum.CLOSED) return true
-  return false
-}
+const isClosedOrPreparing = ({ status }) => isPrepared({ status }) || status === statusEnum.CLOSED
 
-const isPreparingOrOpened = ({ status }) => {
-  if (status === statusEnum.PREPARING || status === statusEnum.OPENED) return true
-  return false
-}
+const isPreparingOrOpened = ({ status }) => isPrepared({ status }) || status === statusEnum.OPENED
 
-const isOpened = ({ status }) => {
-  return status === statusEnum.OPENED
-}
+const isOpened = ({ status }) => status === statusEnum.OPENED
 
-const isClosed = ({ status }) => {
-  if (status === statusEnum.CLOSED) return true
-  return false
-}
+const isClosed = ({ status }) => status === statusEnum.CLOSED
 
 const isPreparing = ({ status, currentMentor, actualMentor }) =>
   isPrepared({ status }) && currentMentor !== actualMentor

--- a/src/pages/exercises/components/toggle-row/index.js
+++ b/src/pages/exercises/components/toggle-row/index.js
@@ -25,13 +25,13 @@ const getStatus = (item) => {
 
 const isPrepared = ({ status }) => status === statusEnum.PREPARING
 
-const isClosedOrPreparing = ({ status }) => isPrepared({ status }) || status === statusEnum.CLOSED
-
-const isPreparingOrOpened = ({ status }) => isPrepared({ status }) || status === statusEnum.OPENED
-
 const isOpened = ({ status }) => status === statusEnum.OPENED
 
 const isClosed = ({ status }) => status === statusEnum.CLOSED
+
+const isPreparingOrOpened = ({ status }) => isPrepared({ status }) || isOpened({ status })
+
+const isClosedOrPreparing = ({ status }) => isPrepared({ status }) || isClosed({ status })
 
 const isPreparing = ({ status, currentMentor, actualMentor }) =>
   isPrepared({ status }) && currentMentor !== actualMentor

--- a/src/pages/exercises/components/toggle-row/index.js
+++ b/src/pages/exercises/components/toggle-row/index.js
@@ -70,19 +70,27 @@ export const ToggleRow = ({ item }) => {
     <>
       <Tr>
         <td>{item.exercise}</td>
-        <td>{item.type ? item.type : t('exercise.toggle-row.type')}</td>
+        <td>{item.type ? item.type : t('exercise.toggleRow.type')}</td>
         <td className='options' colSpan='2'>
           {!isOpened(item)
             ? <Status
               status={getStatus(item)}
               options={{
-                opened: 'Aberto',
-                closed: `Fechado por: ${item.evaluation.mentorName}`,
-                prepairing: `Em preparação por: ${item.evaluation.mentorName}`
+                opened: 'status.opened',
+                closed:
+                  t(
+                    'exercise.toggleRow.status.closed',
+                    { mentor: item.evaluation.mentorName }
+                  ),
+                preparing:
+                  t(
+                    'exercise.toggleRow.status.preparing',
+                    { mentor: item.evaluation.mentorName }
+                  )
               }} />
             : null}
           <ActionButton
-            text={t('exercise.toggle-row.evaluate')}
+            text={t('exercise.toggleRow.evaluate')}
             icon={faPen}
             disabled={isClosed({ status: getStatus(item) }) || isPreparing({ status: getStatus(item) }, item.evaluation.mentorName, mentorNameLocal)}
             onClick={handleSubmit} />

--- a/src/pages/exercises/components/toggle-row/index.js
+++ b/src/pages/exercises/components/toggle-row/index.js
@@ -23,6 +23,8 @@ const getStatus = (item) => {
   return statusEnum.OPENED
 }
 
+const isPrepared = ({ status }) => status === statusEnum.PREPARING
+
 const isClosedOrPreparing = ({ status }) => {
   if (status === statusEnum.PREPARING || status === statusEnum.CLOSED) return true
   return false
@@ -42,10 +44,8 @@ const isClosed = ({ status }) => {
   return false
 }
 
-const isPreparing = ({ status }, mentorName, mentorNameLocal) => {
-  if (status === statusEnum.PREPARING && mentorName !== mentorNameLocal) return true
-  return false
-}
+const isPreparing = ({ status, currentMentor, actualMentor }) =>
+  isPrepared({ status }) && currentMentor !== actualMentor
 
 export const ToggleRow = ({ item }) => {
   const { t } = useTranslation()
@@ -92,7 +92,11 @@ export const ToggleRow = ({ item }) => {
           <ActionButton
             text={t('exercise.toggleRow.evaluate')}
             icon={faPen}
-            disabled={isClosed({ status: getStatus(item) }) || isPreparing({ status: getStatus(item) }, item.evaluation.mentorName, mentorNameLocal)}
+            disabled={isClosed({ status: getStatus(item) }) || isPreparing({
+              status: getStatus(item),
+              currentMentor: item.evaluation.mentorName,
+              actualMentor: mentorNameLocal
+            })}
             onClick={handleSubmit} />
         </td>
         <td className='avaliator-col'>{

--- a/src/utils/i18next/languages/en/common.json
+++ b/src/utils/i18next/languages/en/common.json
@@ -59,14 +59,18 @@
       "delete": "Are you sure you want to delete this item?"
     },
     "status": {
-      "open": "Open",
+      "opened": "Open",
       "closed": "Closed",
       "preparing": "Preparing"
     },
     "exercise":{
-      "toggle-row" :{
+      "toggleRow" :{
         "evaluate" : "Evaluate",
-        "type" : "Undefined"
+        "type" : "Not defined",
+        "status" : {
+          "closed": "Closed by {{mentor}}",
+          "preparing": "Preparing by {{mentor}}"
+        }
       }
     }
   }

--- a/src/utils/i18next/languages/en/common.json
+++ b/src/utils/i18next/languages/en/common.json
@@ -62,6 +62,12 @@
       "open": "Open",
       "closed": "Closed",
       "preparing": "Preparing"
+    },
+    "exercise":{
+      "toggle-row" :{
+        "evaluate" : "Evaluate",
+        "type" : "Undefined"
+      }
     }
   }
 }

--- a/src/utils/i18next/languages/pt/common.json
+++ b/src/utils/i18next/languages/pt/common.json
@@ -62,6 +62,12 @@
       "sendButton": "Enviar",
       "putUrl": "Insira a URL da planilha",
       "saveMensage": "Salvo com sucesso! Quantidade de importações: {{value}}"
+    },
+    "exercise": {
+      "toggle-row" : {
+        "evaluate" : "Avaliação",
+        "type" : "Não definido"
+      }
     }
   }
 }

--- a/src/utils/i18next/languages/pt/common.json
+++ b/src/utils/i18next/languages/pt/common.json
@@ -54,7 +54,7 @@
       "delete": "Deseja excluir o item?"
     },
     "status": {
-      "open": "Aberto",
+      "opened": "Aberto",
       "closed": "Fechado",
       "preparing": "Em preparação"
     },
@@ -64,9 +64,13 @@
       "saveMensage": "Salvo com sucesso! Quantidade de importações: {{value}}"
     },
     "exercise": {
-      "toggle-row" : {
+      "toggleRow" : {
         "evaluate" : "Avaliação",
-        "type" : "Não definido"
+        "type" : "Não definido",
+        "status" : {
+          "closed": "Fechado por {{mentor}}",
+          "preparing": "Em preparação por {{mentor}}"
+        }
       }
     }
   }


### PR DESCRIPTION
# #64 Refact: implementar internacionalização i18next em pages/evaluation/components/toggle-row

# CHANGELOG

- Implementação de internacionalização utilizando i18next em pages/evaluation/components/toggle-row
- Mudança de idioma em alguns componentes da página de Exercise

## Me certifico que:

- [ ]  Não deixei nenhum novo warning, erro ou console.log nas minhas modificações.
- [ ]  Fiz deploy para ambiente de teste, certificando que o build não quebrou.
- [ ]  Solicitei code review para 2 pessoas.
- [ ]  Solicitei QA para 2 pessoas.
- [ ]  Obtive aprovação de QA e posso fazer merge.

# Como testar:

- [x]  Acessar link de teste: https://eluvya-acelera-mais-teste.herokuapp.com/
- [x]  Efetue a troca do idioma do seu navegador (ex: de português para inglês)
- [x]  Atualize a pagina de teste
- [x]  Efetue o login (email: ju@gmail.com senha: 123456) e insira um nome de mentora.
- [x]  Confira se a página de Exercícios está em inglês no campos `tipo` e `avaliador`. Deve aparentar como a imagem abaixo:
![Captura de tela de 2022-01-28 11-25-33](https://user-images.githubusercontent.com/52509940/151564495-ca015e22-4bf2-48c3-8dee-300e1f5a9e20.png)
- [x]  Verifique se todas as funcionalidades estão funcionando normalmente
- [x]  Aplicação não deve conter nenhum erro, warning ou console.log
- [x]  Alteração proposta no card foi implementada