### PR TITLE
66/implementar i18n exercise

### DIFF
--- a/src/pages/exercises/components/exercises-list/index.js
+++ b/src/pages/exercises/components/exercises-list/index.js
@@ -2,8 +2,10 @@ import { useEffect, useState } from 'react'
 import { client } from '../../../../service'
 import { ToggleRow } from '../toggle-row'
 import { ExerciseTable, Container } from './styled'
+import { useTranslation } from 'react-i18next'
 
 export const ExercisesList = () => {
+  const { t } = useTranslation()
   const [exercises, setExercises] = useState([])
 
   useEffect(() => {
@@ -11,7 +13,7 @@ export const ExercisesList = () => {
     client.get(`/exercise?hiringProcessId=${id}`)
       .then(res => setExercises(res.data.data.result))
       .catch(err => {
-        alert('Não foi possível carregar a lista de exercícios.')
+        alert(t('exercise.alert'))
         console.log(err)
         history.back()
       })
@@ -22,10 +24,10 @@ export const ExercisesList = () => {
       <ExerciseTable>
         <thead>
           <tr>
-            <th>Nome </th>
-            <th>Tipo </th>
-            <th colSpan='2'>Avaliador</th>
-            <th>Feedbacks </th>
+            <th>{t('exercise.thead.name')} </th>
+            <th>{t('exercise.thead.type')}</th>
+            <th colSpan='2'>{t('exercise.thead.evaluator')}</th>
+            <th>Feedbacks</th>
           </tr>
         </thead>
         <tbody>

--- a/src/pages/exercises/index.js
+++ b/src/pages/exercises/index.js
@@ -1,12 +1,14 @@
 import { ExercisesList } from '../../pages/exercises/components/exercises-list'
 import Select from '../../components/select'
 import showFeature from '../../utils/feature-toggle'
+import { useTranslation } from 'react-i18next'
 
 export const ExercisesPage = () => {
+  const { t } = useTranslation()
   return (
     <>
       <div className="page-container">
-        <h1>Exercícios</h1>
+        <h1>{t('exercise.title')}</h1>
         {showFeature()
           ? (
             <section>

--- a/src/pages/exercises/index.js
+++ b/src/pages/exercises/index.js
@@ -16,7 +16,7 @@ export const ExercisesPage = () => {
                 { value: 'backend', label: 'Backend' },
                 { value: 'frontend', label: 'Frontend' },
                 { value: 'fullstack', label: 'Fullstack' }
-              ]} placeholder="Tipo" label="Filtrar:" name="type" onChange={() => { }} />
+              ]} placeholder={t('exercise.placeholder')} label="Filtrar:" name="type" onChange={() => { }} />
             </section>)
           : null}
         <ExercisesList />

--- a/src/pages/exercises/index.js
+++ b/src/pages/exercises/index.js
@@ -16,7 +16,7 @@ export const ExercisesPage = () => {
                 { value: 'backend', label: 'Backend' },
                 { value: 'frontend', label: 'Frontend' },
                 { value: 'fullstack', label: 'Fullstack' }
-              ]} placeholder={t('exercise.placeholder')} label="Filtrar:" name="type" onChange={() => { }} />
+              ]} placeholder={t('exercise.select.placeholder')} label={t('exercise.select.label')} name="type" onChange={() => { }} />
             </section>)
           : null}
         <ExercisesList />

--- a/src/utils/i18next/languages/en/common.json
+++ b/src/utils/i18next/languages/en/common.json
@@ -65,7 +65,10 @@
     },
     "exercise": {
       "title": "Exercise",
-      "placeholder": "Type",
+      "select" : {
+        "placeholder": "Type",
+        "label" : "Filter:"
+      },
       "alert": "Could not load exercise list.",
       "thead": {
         "name": "Name",

--- a/src/utils/i18next/languages/en/common.json
+++ b/src/utils/i18next/languages/en/common.json
@@ -65,6 +65,13 @@
     },
     "exercise": {
       "title": "Exercise",
+      "placeholder": "Type",
+      "alert": "Could not load exercise list.",
+      "thead": {
+        "name": "Name",
+        "type": "Type",
+        "evaluator": "Evaluator"
+      },
       "toggleRow": {
         "evaluate": "Evaluate",
         "type": "Not defined",

--- a/src/utils/i18next/languages/en/common.json
+++ b/src/utils/i18next/languages/en/common.json
@@ -63,11 +63,12 @@
       "closed": "Closed",
       "preparing": "Preparing"
     },
-    "exercise":{
-      "toggleRow" :{
-        "evaluate" : "Evaluate",
-        "type" : "Not defined",
-        "status" : {
+    "exercise": {
+      "title": "Exercise",
+      "toggleRow": {
+        "evaluate": "Evaluate",
+        "type": "Not defined",
+        "status": {
           "closed": "Closed by {{mentor}}",
           "preparing": "Preparing by {{mentor}}"
         }

--- a/src/utils/i18next/languages/pt/common.json
+++ b/src/utils/i18next/languages/pt/common.json
@@ -65,10 +65,17 @@
     },
     "exercise": {
       "title": "Exercícios",
-      "toggleRow" : {
-        "evaluate" : "Avaliação",
-        "type" : "Não definido",
-        "status" : {
+      "placeholder": "Tipo",
+      "alert": "Não foi possível carregar a lista de exercícios.",
+      "thead": {
+        "name": "Nome",
+        "type": "Tipo",
+        "evaluator": "Avaliador"
+      },
+      "toggleRow": {
+        "evaluate": "Avaliação",
+        "type": "Não definido",
+        "status": {
           "closed": "Fechado por {{mentor}}",
           "preparing": "Em preparação por {{mentor}}"
         }

--- a/src/utils/i18next/languages/pt/common.json
+++ b/src/utils/i18next/languages/pt/common.json
@@ -65,7 +65,10 @@
     },
     "exercise": {
       "title": "Exercícios",
-      "placeholder": "Tipo",
+      "select" :{
+        "placeholder": "Tipo",
+        "label" : "Filtrar:"
+      },
       "alert": "Não foi possível carregar a lista de exercícios.",
       "thead": {
         "name": "Nome",

--- a/src/utils/i18next/languages/pt/common.json
+++ b/src/utils/i18next/languages/pt/common.json
@@ -64,6 +64,7 @@
       "preparing": "Em preparação"
     },
     "exercise": {
+      "title": "Exercícios",
       "toggleRow" : {
         "evaluate" : "Avaliação",
         "type" : "Não definido",


### PR DESCRIPTION
# # 66/implementar i18n exercise

# CHANGELOG

- Implementação de internacionalização utilizando i18next em pages/exercise
- Mudança de idioma nos componentes da página de Exercise

## Me certifico que:

- [x]  Não deixei nenhum novo warning, erro ou console.log nas minhas modificações.
- [x]  Fiz deploy para ambiente de teste, certificando que o build não quebrou.
- [x]  Solicitei code review para 2 pessoas.
- [x]  Solicitei QA para 2 pessoas.
- [ ]  Obtive aprovação de QA e posso fazer merge.

# Como testar:

- [x]  Acessar link de teste: https://eluvya-acelera-mais-teste.herokuapp.com/
- [x]  Efetue a troca do idioma do seu navegador (ex: de português para inglês)
- [x]  Atualize a pagina de teste
- [x]  Efetue o login (email: ju@gmail.com senha: 123456) e insira um nome de mentora.
- [x]  Confira se toda a página de Exercícios está em inglês
- [x]  Verifique se todas as funcionalidades estão funcionando normalmente
- [ ]  Aplicação não deve conter nenhum erro, warning ou console.log
- [ ]  Alteração proposta no card foi implementada