### PR TITLE
77/listagem de exercicios tela avaliacao

### DIFF
--- a/src/pages/challenges/components/challenges-list/index.js
+++ b/src/pages/challenges/components/challenges-list/index.js
@@ -32,7 +32,7 @@ export const ChallengeList = () => {
         </thead>
         <tbody>
           {challenges.map((challenge, key) => {
-            return <ToggleRow key={`${key}-test`} item={challenge} />
+            return challenge.exercises.length > 0 ? <ToggleRow key={`${key}-test`} item={challenge} /> : null
           })}
         </tbody>
       </ChallengeTable>

--- a/src/pages/challenges/components/toggle-row/index.js
+++ b/src/pages/challenges/components/toggle-row/index.js
@@ -14,9 +14,9 @@ const statusEnum = {
   OPENED: 'status-opened'
 }
 
-const getStatus = (item) => {
-  if (!item.evaluation) return statusEnum.OPENED
-  const { feedback, mentorName } = item.evaluation
+const getStatus = (evaluation) => {
+  if (!evaluation) return statusEnum.OPENED
+  const { feedback, mentorName } = evaluation
   if (mentorName === 'cancelado') return statusEnum.OPENED
   if (feedback && mentorName) return statusEnum.CLOSED
   if (mentorName) return statusEnum.PREPARING
@@ -49,44 +49,48 @@ export const ToggleRow = ({ item }) => {
     setChecked(!checked)
   }
 
-  const handleSubmit = () => {
+  const handleSubmit = (evaluation) => {
     const id = window.location.pathname.split('/').pop()
-    client.patch(`/evaluation/${item.evaluation.id}`, { mentorName: mentorNameLocal })
-    navigate(`/challenges/${item.id}/hiring-process/${id}`)
+    client.patch(`/evaluation/${evaluation.id}`, { mentorName: mentorNameLocal })
+    navigate(`/challenges/${id}/hiring-process/${id}`)
   }
 
   return (
     <>
       <Tr>
         <td>{item.challenge}</td>
-        <td>{item.type ? item.type : t('challenge.toggleRow.type')}</td>
+        <td>{item.type || t('challenge.toggleRow.type')}</td>
         <td className='options' colSpan='2'>
-          {!isOpened(item)
-            ? <Status
-              status={getStatus(item)}
-              options={{
-                opened: 'status.opened',
-                closed:
-                  t(
-                    'challenge.toggleRow.status.closed',
-                    { mentor: item.evaluation.mentorName }
-                  ),
-                preparing:
-                  t(
-                    'challenge.toggleRow.status.preparing',
-                    { mentor: item.evaluation.mentorName }
-                  )
-              }} />
-            : null}
-          <ActionButton
-            text={t('challenge.toggleRow.evaluate')}
-            icon={faPen}
-            disabled={isClosed({ status: getStatus(item) }) || isPreparing({
-              status: getStatus(item),
-              currentMentor: item.evaluation.mentorName,
-              actualMentor: mentorNameLocal
-            })}
-            onClick={handleSubmit} />
+          {item.exercises.map((evaluation, index) => {
+            return (
+              <span key={index}>
+                <Status
+                  status={getStatus(evaluation)}
+                  options={{
+                    opened: 'status.opened',
+                    closed:
+                      t(
+                        'challenge.toggleRow.status.closed',
+                        { mentor: evaluation.mentorName || '' }
+                      ),
+                    preparing:
+                      t(
+                        'challenge.toggleRow.status.preparing',
+                        { mentor: evaluation.mentorName || '' }
+                      )
+                  }} />
+                <ActionButton
+                  text={t('challenge.toggleRow.evaluate')}
+                  icon={faPen}
+                  disabled={isClosed({ status: getStatus(evaluation) }) || isPreparing({
+                    status: getStatus(evaluation),
+                    currentMentor: evaluation.mentorName || '',
+                    actualMentor: mentorNameLocal
+                  })}
+                  onClick={handleSubmit} />
+              </span>)
+          }
+          )}
         </td>
         <td className='avaliator-col'>{
           <Button

--- a/src/pages/evaluation/components/answer/answer.js
+++ b/src/pages/evaluation/components/answer/answer.js
@@ -3,15 +3,15 @@ import { faLink, faCodeBranch } from '@fortawesome/free-solid-svg-icons'
 import { Anchor, Subtitle, AnswerContainer } from '../../styled'
 import { useTranslation } from 'react-i18next'
 
-export const Answer = ({ challenge }) => {
+export const Answer = ({ exercise }) => {
   const { t } = useTranslation()
 
   return (
     <AnswerContainer>
       <Subtitle>{t('evaluation.answer')}</Subtitle>
       <div>
-        {challenge.zip && <Anchor href={challenge.zip} target='_blank' rel='noreferrer'><FontAwesomeIcon icon={faLink} /> Download zip</Anchor>}
-        {challenge.github && <Anchor href={challenge.github} target='_blank' rel='noreferrer'><FontAwesomeIcon icon={faCodeBranch} /> Link do repositório</Anchor>}
+        {exercise.type === 'zip' && <Anchor href={exercise.link} target='_blank' rel='noreferrer'><FontAwesomeIcon icon={faLink} /> Download zip</Anchor>}
+        {exercise.type === 'github' && <Anchor href={exercise.link} target='_blank' rel='noreferrer'><FontAwesomeIcon icon={faCodeBranch} /> Link do repositório</Anchor>}
       </div>
     </AnswerContainer>
   )

--- a/src/pages/evaluation/components/header/header.js
+++ b/src/pages/evaluation/components/header/header.js
@@ -1,15 +1,10 @@
 import { React } from 'react'
 import { Type } from '../select-type/select-type'
 import { HeaderContainer } from '../../styled'
-import { useTranslation } from 'react-i18next'
 
 export const Header = ({ setDisableEvaluationButton }) => {
-  const { t } = useTranslation()
-
   return (
     <HeaderContainer>
-
-      <h1>{t('evaluation.title')}</h1>
 
       <Type setDisableEvaluationButton={setDisableEvaluationButton} />
 

--- a/src/pages/evaluation/components/select-note/select-note.js
+++ b/src/pages/evaluation/components/select-note/select-note.js
@@ -5,7 +5,7 @@ import PrimaryButton from '../../../../components/buttons/primary'
 import { ScoreContainer } from '../../styled'
 import { useTranslation } from 'react-i18next'
 
-export const Score = ({ challenge }) => {
+export const Score = ({ exercise }) => {
   const [feedback, setFeedback] = useState('')
   const [score, setScore] = useState('')
   const { t } = useTranslation()
@@ -24,7 +24,7 @@ export const Score = ({ challenge }) => {
   }
 
   const handleSubmit = () => {
-    const id = challenge.evaluation.id
+    const id = exercise.evaluation.id
     client.patch(`evaluation/${id}`, evaluation)
     alert(t('evaluation.score.alert'))
     history.back()

--- a/src/pages/evaluation/index.js
+++ b/src/pages/evaluation/index.js
@@ -27,8 +27,12 @@ const EvaluationChallenge = () => {
   }, [])
 
   const handleCancel = () => {
-    client.patch(`evaluation/${challenge.evaluation.id}`, { mentorName: 'cancelado' })
-    history.back()
+    challenge.exercises.map((exercise) => {
+      return (
+        client.patch(`evaluation/${exercise.id}`, { mentorName: 'cancelado' }),
+        history.back()
+      )
+    })
   }
 
   if (!challenge) return null
@@ -53,7 +57,7 @@ const EvaluationChallenge = () => {
             <ContainerButtons>
 
               <DefaultButton text={t('evaluation.cancel')} onClick={handleCancel} />
-              <Modal classe={'primary'} text={t('evaluation.evaluate')} title={t('evaluation.title')} disabled={disableEvaluationButton} >
+              <Modal classe={'primary'} text={t('evaluation.evaluate')} title={`${t('evaluation.title')} ${exercise.name}`} disabled={disableEvaluationButton} >
 
                 <Score exercise={exercise} />
 

--- a/src/pages/evaluation/index.js
+++ b/src/pages/evaluation/index.js
@@ -15,10 +15,10 @@ const EvaluationChallenge = () => {
   const [disableEvaluationButton, setDisableEvaluationButton] = useState(true)
   const { t } = useTranslation()
 
-  const id = window.location.pathname.split('/')[2]
+  const challengeId = window.location.pathname.split('/')[2]
 
   useEffect(() => {
-    client.get(`/challenge/${id}`)
+    client.get(`/challenge/${challengeId}`)
       .then(res => (res.data))
       .then(res => setChallenge(res))
       .catch(err => {
@@ -34,32 +34,38 @@ const EvaluationChallenge = () => {
   if (!challenge) return null
 
   return (
+    <>
+      {challenge.exercises.map((exercise) => {
+        return (
+          <Container key={exercise.id}>
 
-    <Container>
+            <Header setDisableEvaluationButton={setDisableEvaluationButton} />
 
-      <Header setDisableEvaluationButton={setDisableEvaluationButton} />
+            <Download>
+              <Anchor href="#" target='_blank' rel='noreferrer'>
+                <FontAwesomeIcon icon={faPrint} />
+                Download: {exercise.name}
+              </Anchor>
+            </Download>
 
-      <Download>
-        <Anchor href="#" target='_blank' rel='noreferrer'>
-          <FontAwesomeIcon icon={faPrint} />
-          Download: {challenge.challenge}
-        </Anchor>
-      </Download>
+            <Answer exercise={exercise} />
 
-      <Answer challenge={challenge} />
+            <ContainerButtons>
 
-      <ContainerButtons>
+              <DefaultButton text={t('evaluation.cancel')} onClick={handleCancel} />
+              <Modal classe={'primary'} text={t('evaluation.evaluate')} title={t('evaluation.title')} disabled={disableEvaluationButton} >
 
-        <DefaultButton text={t('evaluation.cancel')} onClick={handleCancel} />
-        <Modal classe={'primary'} text={t('evaluation.evaluate')} title={t('evaluation.title')} disabled={disableEvaluationButton} >
+                <Score exercise={exercise} />
 
-          <Score challenge={challenge} />
+              </Modal>
 
-        </Modal>
+            </ContainerButtons>
 
-      </ContainerButtons>
-
-    </Container >
+          </Container >
+        )
+      })
+      }
+    </>
   )
 }
 

--- a/src/pages/evaluation/index.js
+++ b/src/pages/evaluation/index.js
@@ -39,36 +39,37 @@ const EvaluationChallenge = () => {
 
   return (
     <>
-      {challenge.exercises.map((exercise) => {
-        return (
-          <Container key={exercise.id}>
+      <Container >
+        <h1>{t('evaluation.title')}</h1>
+        {challenge.exercises.map((exercise) => {
+          return (
+            <div key={exercise.id}>
+              <Header setDisableEvaluationButton={setDisableEvaluationButton} />
 
-            <Header setDisableEvaluationButton={setDisableEvaluationButton} />
+              <Download>
+                <Anchor href="#" target='_blank' rel='noreferrer'>
+                  <FontAwesomeIcon icon={faPrint} />
+                  Download: {exercise.name}
+                </Anchor>
+              </Download>
 
-            <Download>
-              <Anchor href="#" target='_blank' rel='noreferrer'>
-                <FontAwesomeIcon icon={faPrint} />
-                Download: {exercise.name}
-              </Anchor>
-            </Download>
+              <Answer exercise={exercise} />
 
-            <Answer exercise={exercise} />
+              <ContainerButtons>
 
-            <ContainerButtons>
+                <DefaultButton text={t('evaluation.cancel')} onClick={handleCancel} />
+                <Modal classe={'primary'} text={t('evaluation.evaluate')} title={`${t('evaluation.title')} ${exercise.name}`} disabled={disableEvaluationButton} >
 
-              <DefaultButton text={t('evaluation.cancel')} onClick={handleCancel} />
-              <Modal classe={'primary'} text={t('evaluation.evaluate')} title={`${t('evaluation.title')} ${exercise.name}`} disabled={disableEvaluationButton} >
+                  <Score exercise={exercise} />
 
-                <Score exercise={exercise} />
+                </Modal>
 
-              </Modal>
-
-            </ContainerButtons>
-
-          </Container >
-        )
-      })
-      }
+              </ContainerButtons>
+            </div>
+          )
+        })
+        }
+      </Container >
     </>
   )
 }

--- a/src/pages/evaluation/styled.js
+++ b/src/pages/evaluation/styled.js
@@ -26,10 +26,16 @@ export const Container = styled.div`
   padding: 30px;
   width: 100%;
   margin-top: 20px;
+
+  h1 {
+    font-size: 40px;
+    color: rgb(149, 149, 149);
+    font-weight: bold;
+  }
 `
 export const HeaderContainer = styled.section`
   display: flex;
-  justify-content: space-between;
+  justify-content: right;  
 
 h1 {
   font-size: 40px;
@@ -68,7 +74,7 @@ h2 {
 export const ContainerButtons = styled.div`
   display: flex;
   justify-content: right;
-  margin-top: 20px;
+  margin: 20px 0;
   
   & > .primary {
     margin-left: 10px;
@@ -78,6 +84,7 @@ export const TypeContainer = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
+  margin-top: 20px;
   
   & > .sucess {
     margin-left: 10px;

--- a/src/pages/evaluation/styled.js
+++ b/src/pages/evaluation/styled.js
@@ -37,11 +37,6 @@ export const HeaderContainer = styled.section`
   display: flex;
   justify-content: right;  
 
-h1 {
-  font-size: 40px;
-  color: rgb(149, 149, 149);
-  font-weight: bold;
-}
 `
 
 export const Download = styled.div`

--- a/src/utils/i18next/languages/en/common.json
+++ b/src/utils/i18next/languages/en/common.json
@@ -85,7 +85,7 @@
       }
     },
     "evaluation": {
-      "title": "Exercises",
+      "title": "Exercises answers",
       "answer": "Submitted answers:",
       "cancel": "Cancel",
       "evaluate": "Evaluate",

--- a/src/utils/i18next/languages/en/common.json
+++ b/src/utils/i18next/languages/en/common.json
@@ -85,7 +85,7 @@
       }
     },
     "evaluation": {
-      "title": "Evaluation",
+      "title": "Exercises",
       "answer": "Submitted answers:",
       "cancel": "Cancel",
       "evaluate": "Evaluate",

--- a/src/utils/i18next/languages/pt/common.json
+++ b/src/utils/i18next/languages/pt/common.json
@@ -85,7 +85,7 @@
       }
     },
     "evaluation": {
-      "title": "Avaliação",
+      "title": "Exercícios",
       "answer": "Respostas enviadas:",
       "cancel": "Cancelar",
       "evaluate": "Avaliar",

--- a/src/utils/i18next/languages/pt/common.json
+++ b/src/utils/i18next/languages/pt/common.json
@@ -85,7 +85,7 @@
       }
     },
     "evaluation": {
-      "title": "Exercícios",
+      "title": "Respostas dos Exercícios",
       "answer": "Respostas enviadas:",
       "cancel": "Cancelar",
       "evaluate": "Avaliar",


### PR DESCRIPTION
#77 - Listagem de exercicios tela avaliação
====

### 🆙 CHANGELOG

- Apresentação da lista de exercicios na tela de avaliação conforme a quantidade de exercícios que vier da resposta da API, se tiver apenas 1 exercício, apenas 1 deles deve ser exibido

## ⚠️ Me certifico que:

- [x] Não deixei nenhum novo aviso, erro ou console.log nas minhas modificações
- [x]  Fiz deploy para ambiente de teste certificando que o build não quebrou
- [x]  Solicite uma revisão do código para 2 pessoas
- [ ]  Solicitei QA para 2 pessoas
- [ ]  Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:

- [x] Acessar link de teste: https://eluvya-acelera-mais-teste.herokuapp.com/
- [x] Fazer login (e-mail: ju@gmail.com, senha: 123456, nome da mentora: seu nome)
- [x] Verificar se o layout da pagina apresenta este visual:
Obs: pode estar em inglês
![image](https://user-images.githubusercontent.com/79364568/156426477-a6f7bfca-6066-4d3a-a44b-5bac8b63d573.png))
- [x] Clicar nos botões e verificar se eles mantém a funcionalidade proposta
- [ ] Aplicação não deve conter nenhum erro, warning ou console.log
- [ ] Alteração proposta no card foi implementada