### PR TITLE
78/layout alterar tela desafios

### DIFF
--- a/src/components/status/styles.js
+++ b/src/components/status/styles.js
@@ -11,6 +11,7 @@ export const StyledSpan = styled(StatusSpan)`
   padding: 10px 15px;
   text-align: center;
   border-radius: 5px;
+  margin: 2px 0;
   
   &.status-opened {
     background-color: #dcfdd4;

--- a/src/pages/challenges/components/challenges-list/index.js
+++ b/src/pages/challenges/components/challenges-list/index.js
@@ -26,8 +26,7 @@ export const ChallengeList = () => {
           <tr>
             <th>{t('challenge.thead.name')} </th>
             <th>{t('challenge.thead.type')}</th>
-            <th>Teste</th>
-            <th colSpan='2'>{t('challenge.thead.evaluator')}</th>
+            <th colSpan='3'>{t('challenge.thead.evaluator')}</th>
             <th>Feedbacks</th>
           </tr>
         </thead>

--- a/src/pages/challenges/components/challenges-list/index.js
+++ b/src/pages/challenges/components/challenges-list/index.js
@@ -26,6 +26,7 @@ export const ChallengeList = () => {
           <tr>
             <th>{t('challenge.thead.name')} </th>
             <th>{t('challenge.thead.type')}</th>
+            <th>Teste</th>
             <th colSpan='2'>{t('challenge.thead.evaluator')}</th>
             <th>Feedbacks</th>
           </tr>

--- a/src/pages/challenges/components/feedback/index.js
+++ b/src/pages/challenges/components/feedback/index.js
@@ -1,0 +1,18 @@
+export const getFeedback = ({ exercises, toggle }) => {
+  const feedbacks = exercises.filter(exercise => exercise.evaluation.feedback)
+  return (
+    <tr>
+      <td colSpan="6" className={toggle}>
+        <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+          {feedbacks.map((feedback, index) => (
+            <div key={index}>
+              <strong>{feedback.name}</strong>
+              <div>{feedback.evaluation.feedback} </div>
+            </div>
+          )
+          )}
+        </div>
+      </td>
+    </tr>
+  )
+}

--- a/src/pages/challenges/components/feedback/index.js
+++ b/src/pages/challenges/components/feedback/index.js
@@ -3,7 +3,7 @@ export const Feedback = ({ exercises, toggle }) => {
   return (
     <tr>
       <td colSpan="6" className={toggle}>
-        <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-evenly' }}>
           {feedbacks.map((feedback, index) => (
             <div key={index}>
               <strong>{feedback.name}</strong>

--- a/src/pages/challenges/components/feedback/index.js
+++ b/src/pages/challenges/components/feedback/index.js
@@ -1,4 +1,4 @@
-export const getFeedback = ({ exercises, toggle }) => {
+export const Feedback = ({ exercises, toggle }) => {
   const feedbacks = exercises.filter(exercise => exercise.evaluation.feedback)
   return (
     <tr>

--- a/src/pages/challenges/components/helper.js
+++ b/src/pages/challenges/components/helper.js
@@ -74,22 +74,3 @@ export const getNumberChallenge = (exercises) => {
   const closed = statusEvaluation.filter(status => status === statusEnum.CLOSED).length
   return { closed, total: statusEvaluation.length }
 }
-
-/* export const getFeedback = (exercises, toggle) => {
-  const feedbacks = exercises.filter(exercise => exercise.evaluation.feedback)
-  return (
-    <tr>
-      <td colSpan="6" className={toggle}>
-        <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-          {feedbacks.map((feedback, index) => (
-            <div key={index}>
-              <strong>{feedback.name}</strong>
-              <div>{feedback.evaluation.feedback} </div>
-            </div>
-          )
-          )}
-        </div>
-      </td>
-    </tr>
-  )
-} */

--- a/src/pages/challenges/components/helper.js
+++ b/src/pages/challenges/components/helper.js
@@ -1,0 +1,95 @@
+export const statusEnum = {
+  PREPARING: 'status-preparing',
+  CLOSED: 'status-closed',
+  OPENED: 'status-opened'
+}
+
+export const hasFeedback = (challenge) => {
+  if (!challenge.exercises) {
+    return false
+  }
+  return challenge.exercises.find((feed) => feed.feedback !== null)
+}
+
+export const hasMentorName = (challenge) => {
+  if (!challenge.exercises) {
+    return false
+  }
+  return challenge.exercises.find((nameMentor) => nameMentor.mentorName !== null)
+}
+
+export const wasCanceled = (challenge) => {
+  if (!challenge.exercises) {
+    return false
+  }
+  return challenge.exercises.find((name) => name.mentorName === 'cancelado')
+}
+
+export const getStatus = (challenge) => {
+  if (!challenge) return statusEnum.OPENED
+  if (wasCanceled(challenge)) return statusEnum.OPENED
+  if (hasFeedback(challenge) && hasMentorName(challenge)) return statusEnum.CLOSED
+  if (hasMentorName(challenge)) return statusEnum.PREPARING
+  return statusEnum.OPENED
+}
+
+export const getStatusEvaluation = (evaluation) => {
+  if (!evaluation) return statusEnum.OPENED
+  const { feedback, mentorName } = evaluation
+  if (mentorName === 'cancelado') return statusEnum.OPENED
+  if (feedback && mentorName) return statusEnum.CLOSED
+  if (mentorName) return statusEnum.PREPARING
+  return statusEnum.OPENED
+}
+
+export const isClosedChallenge = (exercises) => {
+  return exercises.filter((ex) => getStatusEvaluation(ex.evaluation) !== statusEnum.CLOSED).length === 0
+}
+
+export const isPreparedChallenge = (exercises, mentorNameLocal) => {
+  return exercises.some((ex) => {
+    return isPreparing({
+      status: getStatusEvaluation(ex.evaluation),
+      currentMentor: ex.evaluation.mentorName || '',
+      actualMentor: mentorNameLocal
+    }) === true
+  })
+}
+
+export const isPrepared = ({ status }) => status === statusEnum.PREPARING
+
+export const isOpened = ({ status }) => status === statusEnum.OPENED
+
+export const isClosed = ({ status }) => status === statusEnum.CLOSED
+
+export const isPreparingOrOpened = ({ status }) => isPrepared({ status }) || isOpened({ status })
+
+export const isClosedOrPreparing = ({ status }) => isPrepared({ status }) || isClosed({ status })
+
+export const isPreparing = ({ status, currentMentor, actualMentor }) =>
+  isPrepared({ status }) && currentMentor !== actualMentor
+
+export const getNumberChallenge = (exercises) => {
+  const statusEvaluation = exercises.map(exercise => getStatusEvaluation(exercise.evaluation))
+  const closed = statusEvaluation.filter(status => status === statusEnum.CLOSED).length
+  return { closed, total: statusEvaluation.length }
+}
+
+/* export const getFeedback = (exercises, toggle) => {
+  const feedbacks = exercises.filter(exercise => exercise.evaluation.feedback)
+  return (
+    <tr>
+      <td colSpan="6" className={toggle}>
+        <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+          {feedbacks.map((feedback, index) => (
+            <div key={index}>
+              <strong>{feedback.name}</strong>
+              <div>{feedback.evaluation.feedback} </div>
+            </div>
+          )
+          )}
+        </div>
+      </td>
+    </tr>
+  )
+} */

--- a/src/pages/challenges/components/toggle-row/index.js
+++ b/src/pages/challenges/components/toggle-row/index.js
@@ -79,6 +79,12 @@ const isClosedOrPreparing = ({ status }) => isPrepared({ status }) || isClosed({
 const isPreparing = ({ status, currentMentor, actualMentor }) =>
   isPrepared({ status }) && currentMentor !== actualMentor
 
+const getNumberChallenge = (exercises) => {
+  const statusEvaluation = exercises.map(exercise => getStatusEvaluation(exercise.evaluation))
+  const closed = statusEvaluation.filter(status => status === statusEnum.CLOSED).length
+  return { closed, total: statusEvaluation.length }
+}
+
 const getFeedback = (exercises, toggle) => {
   const feedbacks = exercises.filter(exercise => exercise.evaluation.feedback)
   return (
@@ -105,8 +111,7 @@ export const ToggleRow = ({ item }) => {
   const [mentorNameLocal] = useState(localStorage.getItem('mentorName'))
   const toggle = checked ? 'toggle-on' : 'toggle-off'
   const status = isClosedOrPreparing({ status: getStatus(item) })
-
-  console.log(item)
+  const countExercise = getNumberChallenge(item.exercises)
 
   const handleClick = () => {
     setChecked(!checked)
@@ -120,14 +125,12 @@ export const ToggleRow = ({ item }) => {
     navigate(`/challenges/${item.id}/hiring-process/${id}`)
   }
 
-  console.log(item)
-
   return (
     <>
       <Tr>
         <td>{item.challenge}</td>
         <td>{item.type || t('challenge.toggleRow.type')}</td>
-        <td>numero</td>
+        <td style={{ color: '#4fac16', fontWeight: 'bold' }}>{countExercise.closed}/{countExercise.total}</td>
         <td className='options'>
           <div>
             {item.exercises.map((excercise) => (

--- a/src/pages/challenges/components/toggle-row/index.js
+++ b/src/pages/challenges/components/toggle-row/index.js
@@ -7,6 +7,7 @@ import { client } from '../../../../service'
 import { useNavigate } from 'react-router-dom'
 import { Tr } from './styled'
 import { useTranslation } from 'react-i18next'
+import { Feedback } from '../feedback'
 import {
   getNumberChallenge,
   getStatus,
@@ -82,7 +83,7 @@ export const ToggleRow = ({ item }) => {
             icon={faAngleDown} />
         }</td>
       </Tr>
-      {status && hasFeedback(item) ? <getFeedback exercises={item} toggle={item} /> : null}
+      {status && hasFeedback(item) ? <Feedback exercises={item.exercises} toggle={toggle} /> : null}
     </>
   )
 }

--- a/src/pages/challenges/components/toggle-row/index.js
+++ b/src/pages/challenges/components/toggle-row/index.js
@@ -83,7 +83,7 @@ const getFeedback = (exercises, toggle) => {
   const feedbacks = exercises.filter(exercise => exercise.evaluation.feedback)
   return (
     <tr>
-      <td colSpan="5" className={toggle}>
+      <td colSpan="6" className={toggle}>
         <div style={{ display: 'flex', justifyContent: 'space-between' }}>
           {feedbacks.map((feedback, index) => (
             <div key={index}>
@@ -106,6 +106,8 @@ export const ToggleRow = ({ item }) => {
   const toggle = checked ? 'toggle-on' : 'toggle-off'
   const status = isClosedOrPreparing({ status: getStatus(item) })
 
+  console.log(item)
+
   const handleClick = () => {
     setChecked(!checked)
   }
@@ -118,32 +120,37 @@ export const ToggleRow = ({ item }) => {
     navigate(`/challenges/${item.id}/hiring-process/${id}`)
   }
 
+  console.log(item)
+
   return (
     <>
       <Tr>
         <td>{item.challenge}</td>
         <td>{item.type || t('challenge.toggleRow.type')}</td>
         <td>numero</td>
-        <td className='options' colSpan='2'>
-          {item.exercises.map((excercise) => {
-            return (<Status key={excercise.id}
-              status={getStatusEvaluation(excercise.evaluation)}
-              options={{
-                opened: 'status.opened',
-                closed:
-                  t(
-                    'challenge.toggleRow.status.closed',
-                    { mentor: excercise.evaluation.mentorName || '' }
-                  ),
-                preparing:
-                  t(
-                    'challenge.toggleRow.status.preparing',
-                    { mentor: excercise.evaluation.mentorName || '' }
-                  )
-              }} />
+        <td className='options'>
+          <div>
+            {item.exercises.map((excercise) => (
+              <Status key={excercise.id}
+                status={getStatusEvaluation(excercise.evaluation)}
+                options={{
+                  opened: 'status.opened',
+                  closed:
+                    t(
+                      'challenge.toggleRow.status.closed',
+                      { mentor: excercise.evaluation.mentorName || '' }
+                    ),
+                  preparing:
+                    t(
+                      'challenge.toggleRow.status.preparing',
+                      { mentor: excercise.evaluation.mentorName || '' }
+                    )
+                }} />
             )
-          }
-          )}
+            )}
+          </div>
+        </td>
+        <td>
           < ActionButton
             text={t('challenge.toggleRow.evaluate')}
             icon={faPen}

--- a/src/pages/challenges/components/toggle-row/index.js
+++ b/src/pages/challenges/components/toggle-row/index.js
@@ -79,13 +79,25 @@ const isClosedOrPreparing = ({ status }) => isPrepared({ status }) || isClosed({
 const isPreparing = ({ status, currentMentor, actualMentor }) =>
   isPrepared({ status }) && currentMentor !== actualMentor
 
+const getFeedback = (exercises, toggle) => {
+  const feedbacks = []
+  for (let index = 0; index < 3; index++) {
+    const feed = exercises[index] ? exercises[index].evaluation.feedback : null
+    feedbacks.push({ id: index, name: exercises.name, feedback: feed })
+  }
+  return (
+    <tr>
+      {feedbacks.map(feed => <td key={feed.id} colSpan='2' className={toggle}>{feed.name}{feed.feedback} </td>)}
+    </tr>
+  )
+}
+
 export const ToggleRow = ({ item }) => {
   const { t } = useTranslation()
   const [checked, setChecked] = useState(false)
   const navigate = useNavigate()
   const [mentorNameLocal] = useState(localStorage.getItem('mentorName'))
   const toggle = checked ? 'toggle-on' : 'toggle-off'
-  const feedback = item?.evaluation?.feedback || ''
   const status = isClosedOrPreparing({ status: getStatus(item) })
 
   const handleClick = () => {
@@ -140,7 +152,7 @@ export const ToggleRow = ({ item }) => {
             icon={faAngleDown} />
         }</td>
       </Tr>
-      {status && hasFeedback(item) ? <tr><td colSpan='5' className={toggle}>{feedback}</td></tr> : null}
+      {status && hasFeedback(item) ? getFeedback(item.exercises, toggle) : null}
     </>
   )
 }

--- a/src/pages/challenges/components/toggle-row/index.js
+++ b/src/pages/challenges/components/toggle-row/index.js
@@ -80,14 +80,20 @@ const isPreparing = ({ status, currentMentor, actualMentor }) =>
   isPrepared({ status }) && currentMentor !== actualMentor
 
 const getFeedback = (exercises, toggle) => {
-  const feedbacks = []
-  for (let index = 0; index < 3; index++) {
-    const feed = exercises[index] ? exercises[index].evaluation.feedback : null
-    feedbacks.push({ id: index, name: exercises.name, feedback: feed })
-  }
+  const feedbacks = exercises.filter(exercise => exercise.evaluation.feedback)
   return (
     <tr>
-      {feedbacks.map(feed => <td key={feed.id} colSpan='2' className={toggle}>{feed.name}{feed.feedback} </td>)}
+      <td colSpan="5" className={toggle}>
+        <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+          {feedbacks.map((feedback, index) => (
+            <div key={index}>
+              <strong>{feedback.name}</strong>
+              <div>{feedback.evaluation.feedback} </div>
+            </div>
+          )
+          )}
+        </div>
+      </td>
     </tr>
   )
 }

--- a/src/pages/challenges/components/toggle-row/index.js
+++ b/src/pages/challenges/components/toggle-row/index.js
@@ -14,7 +14,30 @@ const statusEnum = {
   OPENED: 'status-opened'
 }
 
-const getStatus = (evaluation) => {
+const hasFeedback = (challenge) => {
+  return true
+}
+
+const hasMentorName = (challenge) => {
+  return true
+}
+
+const wasCanceled = (challenge) => {
+  if (challenge.exercises.find(name => name.evaluation.mentorName === 'cancelado')) {
+    return true
+  }
+  /* return false */
+}
+
+const getStatus = (challenge) => {
+  if (!challenge) return statusEnum.OPENED
+  if (wasCanceled(challenge)) return statusEnum.OPENED
+  if (hasFeedback(challenge) && hasMentorName(challenge)) return statusEnum.CLOSED
+  if (hasMentorName(challenge)) return statusEnum.PREPARING
+  return statusEnum.OPENED
+}
+
+const getStatus2 = (evaluation) => {
   if (!evaluation) return statusEnum.OPENED
   const { feedback, mentorName } = evaluation
   if (mentorName === 'cancelado') return statusEnum.OPENED
@@ -76,10 +99,11 @@ export const ToggleRow = ({ item }) => {
       <Tr>
         <td>{item.challenge}</td>
         <td>{item.type || t('challenge.toggleRow.type')}</td>
+        <td>numero</td>
         <td className='options' colSpan='2'>
           {item.exercises.map((excercise) => {
             return (<Status key={excercise.id}
-              status={getStatus(excercise.evaluation)}
+              status={getStatus2(excercise.evaluation)}
               options={{
                 opened: 'status.opened',
                 closed:
@@ -96,13 +120,11 @@ export const ToggleRow = ({ item }) => {
             )
           }
           )}
-
           < ActionButton
             text={t('challenge.toggleRow.evaluate')}
             icon={faPen}
             disabled={isClosedChallenge(item.exercises) || isPreparedChallenge(item.exercises, mentorNameLocal)}
             onClick={handleSubmit} />
-
         </td>
         <td className='avaliator-col'>{
           <Button
@@ -112,7 +134,7 @@ export const ToggleRow = ({ item }) => {
             icon={faAngleDown} />
         }</td>
       </Tr>
-      {status && feedback !== '' ? <tr><td colSpan='5' className={toggle}>{feedback}</td></tr> : null}
+      {status && hasFeedback(item) ? <tr><td colSpan='5' className={toggle}>{feedback}</td></tr> : null}
     </>
   )
 }

--- a/src/pages/challenges/components/toggle-row/index.js
+++ b/src/pages/challenges/components/toggle-row/index.js
@@ -7,102 +7,16 @@ import { client } from '../../../../service'
 import { useNavigate } from 'react-router-dom'
 import { Tr } from './styled'
 import { useTranslation } from 'react-i18next'
-
-const statusEnum = {
-  PREPARING: 'status-preparing',
-  CLOSED: 'status-closed',
-  OPENED: 'status-opened'
-}
-
-const hasFeedback = (challenge) => {
-  if (!challenge.exercises) {
-    return false
-  }
-  return challenge.exercises.find((feed) => feed.feedback !== null)
-}
-
-const hasMentorName = (challenge) => {
-  if (!challenge.exercises) {
-    return false
-  }
-  return challenge.exercises.find((nameMentor) => nameMentor.mentorName !== null)
-}
-
-const wasCanceled = (challenge) => {
-  if (!challenge.exercises) {
-    return false
-  }
-  return challenge.exercises.find((name) => name.mentorName === 'cancelado')
-}
-
-const getStatus = (challenge) => {
-  if (!challenge) return statusEnum.OPENED
-  if (wasCanceled(challenge)) return statusEnum.OPENED
-  if (hasFeedback(challenge) && hasMentorName(challenge)) return statusEnum.CLOSED
-  if (hasMentorName(challenge)) return statusEnum.PREPARING
-  return statusEnum.OPENED
-}
-
-const getStatusEvaluation = (evaluation) => {
-  if (!evaluation) return statusEnum.OPENED
-  const { feedback, mentorName } = evaluation
-  if (mentorName === 'cancelado') return statusEnum.OPENED
-  if (feedback && mentorName) return statusEnum.CLOSED
-  if (mentorName) return statusEnum.PREPARING
-  return statusEnum.OPENED
-}
-
-const isClosedChallenge = (exercises) => {
-  return exercises.filter((ex) => getStatusEvaluation(ex.evaluation) !== statusEnum.CLOSED).length === 0
-}
-
-const isPreparedChallenge = (exercises, mentorNameLocal) => {
-  return exercises.some((ex) => {
-    return isPreparing({
-      status: getStatusEvaluation(ex.evaluation),
-      currentMentor: ex.evaluation.mentorName || '',
-      actualMentor: mentorNameLocal
-    }) === true
-  })
-}
-
-const isPrepared = ({ status }) => status === statusEnum.PREPARING
-
-const isOpened = ({ status }) => status === statusEnum.OPENED
-
-const isClosed = ({ status }) => status === statusEnum.CLOSED
-
-const isPreparingOrOpened = ({ status }) => isPrepared({ status }) || isOpened({ status })
-
-const isClosedOrPreparing = ({ status }) => isPrepared({ status }) || isClosed({ status })
-
-const isPreparing = ({ status, currentMentor, actualMentor }) =>
-  isPrepared({ status }) && currentMentor !== actualMentor
-
-const getNumberChallenge = (exercises) => {
-  const statusEvaluation = exercises.map(exercise => getStatusEvaluation(exercise.evaluation))
-  const closed = statusEvaluation.filter(status => status === statusEnum.CLOSED).length
-  return { closed, total: statusEvaluation.length }
-}
-
-const getFeedback = (exercises, toggle) => {
-  const feedbacks = exercises.filter(exercise => exercise.evaluation.feedback)
-  return (
-    <tr>
-      <td colSpan="6" className={toggle}>
-        <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-          {feedbacks.map((feedback, index) => (
-            <div key={index}>
-              <strong>{feedback.name}</strong>
-              <div>{feedback.evaluation.feedback} </div>
-            </div>
-          )
-          )}
-        </div>
-      </td>
-    </tr>
-  )
-}
+import {
+  getNumberChallenge,
+  getStatus,
+  getStatusEvaluation,
+  hasFeedback,
+  isClosedChallenge,
+  isClosedOrPreparing,
+  isPreparedChallenge,
+  isPreparingOrOpened
+} from '../helper'
 
 export const ToggleRow = ({ item }) => {
   const { t } = useTranslation()
@@ -168,7 +82,7 @@ export const ToggleRow = ({ item }) => {
             icon={faAngleDown} />
         }</td>
       </Tr>
-      {status && hasFeedback(item) ? getFeedback(item.exercises, toggle) : null}
+      {status && hasFeedback(item) ? <getFeedback exercises={item} toggle={item} /> : null}
     </>
   )
 }

--- a/src/pages/challenges/components/toggle-row/index.js
+++ b/src/pages/challenges/components/toggle-row/index.js
@@ -15,11 +15,17 @@ const statusEnum = {
 }
 
 const hasFeedback = (challenge) => {
-  return true
+  if (!challenge.exercises) {
+    return false
+  }
+  return challenge.exercises.find((feed) => feed.feedback !== null)
 }
 
 const hasMentorName = (challenge) => {
-  return true
+  if (!challenge.exercises) {
+    return false
+  }
+  return challenge.exercises.find((nameMentor) => nameMentor.mentorName !== null)
 }
 
 const wasCanceled = (challenge) => {
@@ -37,7 +43,7 @@ const getStatus = (challenge) => {
   return statusEnum.OPENED
 }
 
-const getStatus2 = (evaluation) => {
+const getStatusEvaluation = (evaluation) => {
   if (!evaluation) return statusEnum.OPENED
   const { feedback, mentorName } = evaluation
   if (mentorName === 'cancelado') return statusEnum.OPENED
@@ -47,13 +53,13 @@ const getStatus2 = (evaluation) => {
 }
 
 const isClosedChallenge = (exercises) => {
-  return exercises.filter((ex) => getStatus(ex.evaluation) !== statusEnum.CLOSED).length === 0
+  return exercises.filter((ex) => getStatusEvaluation(ex.evaluation) !== statusEnum.CLOSED).length === 0
 }
 
 const isPreparedChallenge = (exercises, mentorNameLocal) => {
   return exercises.some((ex) => {
     return isPreparing({
-      status: getStatus(ex.evaluation),
+      status: getStatusEvaluation(ex.evaluation),
       currentMentor: ex.evaluation.mentorName || '',
       actualMentor: mentorNameLocal
     }) === true
@@ -103,7 +109,7 @@ export const ToggleRow = ({ item }) => {
         <td className='options' colSpan='2'>
           {item.exercises.map((excercise) => {
             return (<Status key={excercise.id}
-              status={getStatus2(excercise.evaluation)}
+              status={getStatusEvaluation(excercise.evaluation)}
               options={{
                 opened: 'status.opened',
                 closed:

--- a/src/pages/challenges/components/toggle-row/index.js
+++ b/src/pages/challenges/components/toggle-row/index.js
@@ -23,10 +23,10 @@ const hasMentorName = (challenge) => {
 }
 
 const wasCanceled = (challenge) => {
-  if (challenge.exercises.find(name => name.evaluation.mentorName === 'cancelado')) {
-    return true
+  if (!challenge.exercises) {
+    return false
   }
-  /* return false */
+  return challenge.exercises.find((name) => name.mentorName === 'cancelado')
 }
 
 const getStatus = (challenge) => {

--- a/src/pages/challenges/components/toggle-row/styled.js
+++ b/src/pages/challenges/components/toggle-row/styled.js
@@ -18,6 +18,11 @@ export const Tr = styled.tr`
     margin-left: 20px;
   }
 
+  .options {
+    display: flex;
+    flex-direction: column;
+  }
+
   .primary {
     padding: 5px 10px;
   }

--- a/src/pages/challenges/components/toggle-row/styled.js
+++ b/src/pages/challenges/components/toggle-row/styled.js
@@ -18,7 +18,7 @@ export const Tr = styled.tr`
     margin-left: 20px;
   }
 
-  .options {
+  div {
     display: flex;
     flex-direction: column;
   }


### PR DESCRIPTION
78/layout alterar tela desafios
====

### 🆙 CHANGELOG

- Apresentação da lista de exercícios na tela de desafios conforme a quantidade de exercícios que vier da resposta da API, se tiver apenas 1 exercício, apenas 1 deles deve ser exibido.

## ⚠️ Me certifico que:

- [x] Não deixei nenhum novo aviso, erro ou console.log nas minhas modificações
- [x]  Fiz deploy para ambiente de teste certificando que o build não quebrou
- [x]  Solicite uma revisão do código para 2 pessoas
- [x]  Solicitei QA para 2 pessoas
- [ ]  Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:

- [x] Acessar link de teste: https://eluvya-acelera-mais-teste.herokuapp.com/
- [x] Fazer login (e-mail: ju@gmail.com, senha: 123456, nome da mentora: seu nome)
- [x] Crie um novo processo seletivo
- [x] Importe as planilhas atualizadas
   - `CANDIDATAS:` https://docs.google.com/spreadsheets/d/1otPHEw6kHc_Yn3vbTp23fNYJD6MmK-HPl5_GXjZ0kcI/edit?pli=1#gid=202090629
   - `EXERCÍCIOS:` https://docs.google.com/spreadsheets/d/13pIgJAPUDk-6OgJ4Ecfm9vCrlzyLLpFp3E25cb-2dF0/edit#gid=549640884
- [x] Verificar se o layout da pagina apresenta este visual:
![image](https://user-images.githubusercontent.com/92865717/158428770-8b3d31a5-fc6a-4a6f-bee0-94e24fb82d5e.png)
![image](https://user-images.githubusercontent.com/92865717/158429213-c9854fb8-f14f-4ca5-bac2-b250318ec658.png)
- [x] Clicar nos botões e verificar se eles mantém a funcionalidade proposta
- [ ] Aplicação não deve conter nenhum erro, warning ou console.log
- [ ] Alteração proposta no card foi implementada