### PR TITLE
Login: Não exigir nome do mentor

### DIFF
--- a/src/pages/authentication/forms/login/index.js
+++ b/src/pages/authentication/forms/login/index.js
@@ -8,7 +8,6 @@ export const Login = () => {
   const { t } = useTranslation()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
-  // const [mentorName, setMentorName] = useState('')
   const navigate = useNavigate()
 
   const handleChangeEmail = ({ target }) => {
@@ -18,11 +17,6 @@ export const Login = () => {
   const handleChangePassword = ({ target }) => {
     setPassword(target.value)
   }
-
-  // const handleChangeMentorName = ({ target }) => {
-  //   setMentorName(target.value)
-  //   localStorage.setItem('mentorName', target.value)
-  // }
 
   const handlerClick = async (event) => {
     event.preventDefault()

--- a/src/pages/authentication/forms/login/index.js
+++ b/src/pages/authentication/forms/login/index.js
@@ -8,7 +8,7 @@ export const Login = () => {
   const { t } = useTranslation()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
-  const [mentorName, setMentorName] = useState('')
+  // const [mentorName, setMentorName] = useState('')
   const navigate = useNavigate()
 
   const handleChangeEmail = ({ target }) => {
@@ -19,10 +19,10 @@ export const Login = () => {
     setPassword(target.value)
   }
 
-  const handleChangeMentorName = ({ target }) => {
-    setMentorName(target.value)
-    localStorage.setItem('mentorName', target.value)
-  }
+  // const handleChangeMentorName = ({ target }) => {
+  //   setMentorName(target.value)
+  //   localStorage.setItem('mentorName', target.value)
+  // }
 
   const handlerClick = async (event) => {
     event.preventDefault()
@@ -36,7 +36,7 @@ export const Login = () => {
 
     try {
       const response = await client.post('/login', user)
-      const { data: { accessToken, auth, user: { role } } } = response
+      const { data: { accessToken, auth, user: { role, name } } } = response
 
       if (accessToken) {
         if (!auth) {
@@ -44,6 +44,7 @@ export const Login = () => {
         }
         localStorage.setItem('token', accessToken)
         localStorage.setItem('role', role)
+        localStorage.setItem('mentorName', name)
         setTokenInHeaders(accessToken)
         navigate('/home')
       }
@@ -61,9 +62,6 @@ export const Login = () => {
         </label>
         <label>
           <input onChange={handleChangePassword} value={password} type="password" placeholder={t('login.password')}></input>
-        </label>
-        <label>
-          <input onChange={handleChangeMentorName} value={mentorName} type="text" placeholder={t('login.mentorName')}></input>
         </label>
       </div>
       <button onClick={handlerClick}>{t('login.loginButton')}</button>


### PR DESCRIPTION
#123  - Login: Não exigir nome do mentor
====
  
### 🆙 CHANGELOG

- Remove input que solicitava nome do mentor avaliador
- Remove lógica que salvava no localstorage o nome digitado no input de mentor avaliador
- Salva no localstorage o nome do usuário que realizou login

## ⚠️ Me certifico que:

- [x] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [x] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [x] Solicitei **code review** para 2 pessoas
- [x] Solicitei **QA** para 2 pessoas
- [x] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:

- [x] Abra o link https://leo-acelera-mais-front.herokuapp.com
- [x] Verifique se ao abrir, a seguinte interface é apresentada:
 ![prototype login](https://user-images.githubusercontent.com/52937899/174656032-bd6c9234-e21c-4d1c-b8e9-b75b64505215.png)
- [x] Realize login com o email: leonardogomespadilha@gmail.com e a senha: jyql7qm4hx
- [x] Vá para processos seletivos, selecione um existente e clique para avaliar um exercício
- [x] Após isso, volte para a listagem dos exercícios e verifique se o selecionado contém o seu nome como avaliador
- [x] Aplicação não deve conter nenhum erro, warning ou console.log
- [x] Alteração proposta no card foi implementada
