### PR TITLE
feat(pages/home): restringe o acesso do botao gerenciamento de mentoras para admin

### DIFF
--- a/src/components/is-auth/index.js
+++ b/src/components/is-auth/index.js
@@ -1,10 +1,11 @@
 import React from 'react'
 import { Navigate, Outlet, useLocation } from 'react-router-dom'
 
-export const IsAuth = (props) => {
+export const IsAuth = ({ mentorType = ['admin', 'mentor'] }) => {
   const location = useLocation()
+  const role = localStorage.getItem('role')
 
-  if (localStorage.getItem('token')) {
+  if (localStorage.getItem('token') && mentorType.includes(role)) {
     return <Outlet />
   }
   return <Navigate to="/" state={{ from: location }} />

--- a/src/pages/home/index.js
+++ b/src/pages/home/index.js
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next'
 import { faChevronCircleRight } from '@fortawesome/free-solid-svg-icons'
 import { HomePageContainer, HomeContainer } from './styled'
 import { Hyperlink } from '../../components/hyperlink'
+import { isAdmin } from '../../utils/isAdmin'
 
 export const HomePage = () => {
   const { t } = useTranslation()
@@ -10,7 +11,8 @@ export const HomePage = () => {
       <h1>{t('home.title')}</h1>
       <HomeContainer>
         <Hyperlink link="/hiring-process" label={t('hiringProcess.title')} icon={faChevronCircleRight} />
-        <Hyperlink link="/user" label={t('home.manageMentor')} icon={faChevronCircleRight} />
+        {isAdmin() &&
+          <Hyperlink link="/user" label={t('home.manageMentor')} icon={faChevronCircleRight} />}
       </HomeContainer>
     </HomePageContainer>
   )

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -6,6 +6,7 @@ import { IsAuth } from '../components/is-auth/index.js'
 import { ChallengePage } from '../pages/challenges'
 import Evaluation from '../pages/evaluation'
 import MentorPage from '../pages/user'
+
 const AppRoutes = () => {
   return (
     <BrowserRouter>
@@ -15,7 +16,7 @@ const AppRoutes = () => {
         <Route path="/hiring-process" element={<IsAuth />}>
           <Route path="/hiring-process" element={<HiringProcessPage />} exact />
         </Route>
-        <Route path="/user" element={<IsAuth />}>
+        <Route path="/user" element={<IsAuth mentorType={['admin']} />}>
           <Route path="/user" element={<MentorPage />} exact />
         </Route>
         <Route path="/challenges" element={<IsAuth />}>


### PR DESCRIPTION
@drebarcelos @lodmina

#<138> - Mentoras avaliadoras estão com acesso ao cadastro de mentoras
====
  
### 🆙 CHANGELOG

Na página `'Home'`, o botão `'Gerenciamento de Mentoras'` não aparece para as mentoras avaliadoras, esta
disponível somente para a mentora administradora

## ⚠️ Me certifico que:

- [x] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [x] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [x] Solicitei **code review** para 2 pessoas
- [x] Solicitei **QA** para 2 pessoas
- [x] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:

- [x] Acessar pelo link: https://andressa-acelera-mais-front.herokuapp.com/
      login: ludmilakdk@gmail.com
      senha: 182ojyiy17
- [x] Na pagina `'Home'` deve estar aparecendo apenas o botão `'Processos Seletivos'`
- [x] Aplicação não deve conter nenhum erro, warning ou console.log
- [x] Alteração proposta no card foi implementada
