### PR TITLE
151/ Refatorar as ações disponíveis na listagem de processos seletivos

### DIFF
--- a/src/pages/hiring-process/components/hiring-process-list/index.js
+++ b/src/pages/hiring-process/components/hiring-process-list/index.js
@@ -9,7 +9,7 @@ import { client } from '../../../../service'
 import {
   faAngleDown,
   faDownload,
-  faUpload, faTrashAlt
+  faUpload
 } from '@fortawesome/free-solid-svg-icons'
 import { Link } from 'react-router-dom'
 import { parse } from 'json2csv'
@@ -36,17 +36,7 @@ export const ProcessList = ({ processes, setHiringProcesses }) => {
     location.reload()
   }
 
-  const handleDelete = async (id) => {
-    try {
-      const answer = confirm(t('hiringProcess.delete'))
-      if (answer === false) return
-      client.delete(`/hiring_process/${id}`)
-      const newProcesses = processes.filter(process => process.id !== id)
-      setHiringProcesses(newProcesses)
-    } catch (error) {
-      console.error(error)
-    }
-  }
+  const isHiringProcessOpen = (status) => status === 'status-opened'
 
   const formatDate = (date) => {
     const addZero = (number) => number <= 9 ? '0' + number : number
@@ -124,7 +114,8 @@ export const ProcessList = ({ processes, setHiringProcesses }) => {
                   label="Editar"
                   title={t('hiringProcess.edit.title')}
                   className="button action"
-                  text={t('hiringProcess.edit.text')}>
+                  text={t('hiringProcess.edit.text')}
+                  disabled={!isHiringProcessOpen(process.status)}>
                   <HiringProcessForm
                     callback={handleEdit}
                     method="PATCH"
@@ -142,12 +133,6 @@ export const ProcessList = ({ processes, setHiringProcesses }) => {
                   />
                 </td>)
                 : null}
-              {isAdmin() && <td>
-                <Button icon={faTrashAlt}
-                  className="button delete"
-                  onClick={() => handleDelete(process.id)}
-                />
-              </td>}
             </tr>
           ))}
         </tbody>

--- a/src/pages/hiring-process/components/hiring-process-list/index.js
+++ b/src/pages/hiring-process/components/hiring-process-list/index.js
@@ -18,7 +18,7 @@ import { Container, HiringProcessTable } from './styles'
 import { isAdmin } from '../../../../utils/isAdmin'
 import { useTranslation } from 'react-i18next'
 
-export const ProcessList = ({ processes, setHiringProcesses }) => {
+export const ProcessList = ({ processes }) => {
   const { t } = useTranslation()
   const [csv, setCSV] = useState('')
 
@@ -36,7 +36,7 @@ export const ProcessList = ({ processes, setHiringProcesses }) => {
     location.reload()
   }
 
-  const isHiringProcessOpen = (status) => status === 'status-opened'
+  const isHiringProcessClosed = (status) => status === 'status-closed'
 
   const formatDate = (date) => {
     const addZero = (number) => number <= 9 ? '0' + number : number
@@ -115,7 +115,7 @@ export const ProcessList = ({ processes, setHiringProcesses }) => {
                   title={t('hiringProcess.edit.title')}
                   className="button action"
                   text={t('hiringProcess.edit.text')}
-                  disabled={!isHiringProcessOpen(process.status)}>
+                  disabled={isHiringProcessClosed(process.status)}>
                   <HiringProcessForm
                     callback={handleEdit}
                     method="PATCH"


### PR DESCRIPTION

#151 - Refatorar as ações disponíveis na listagem de processos seletivos
====
  
### 🆙 CHANGELOG
- Remoção do botão de excluir processo seletivo (/hiring-process).
- Criação de função para verificar status do processo seletivo {isHiringProcessOpen()}
- Desabilitação do botão de editar processo seletivo quando este estiver fechado.

## ⚠️ Me certifico que:

- [x] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [x] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [x] Solicitei **code review** para 2 pessoas
- [x] Solicitei **QA** para 2 pessoas
- [x] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:

*Esses passos são apenas exemplos*

- [x] Acessar a branch "151/refatorar-acoes-na-pagina-processos-seletivos" no front-end da aplicação Acelera Mais.
- [x] Iniciar a aplicação
- [x] Realizar login com um usuário admin.
- [x] Ir na página de Processos Seletivos.
- [x] Verificar que o botão de excluir processo seletivo não existe.
- [x] Tentar editar um processo seletivo fechado e não obter êxito.
- [x] Tentar editar um processo seletivo aberto e obter êxito.
- [x] Aplicação não deve conter nenhum erro, warning ou console.log
- [x] Alteração proposta no card foi implementada.
