### PR TITLE
221/Transformar index.css em styled-components

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,7 @@ import AppRoutes from './routes'
 const App = () => {
   return (
     <>
-      <GlobalStyle />,
+      <GlobalStyle />
       <AppRoutes />
     </>
   )

--- a/src/App.js
+++ b/src/App.js
@@ -1,8 +1,12 @@
+import { GlobalStyle } from './globalStyles'
 import AppRoutes from './routes'
 
 const App = () => {
   return (
+    <>
+      <GlobalStyle />,
       <AppRoutes />
+    </>
   )
 }
 

--- a/src/globalStyles.js
+++ b/src/globalStyles.js
@@ -1,7 +1,6 @@
-/* http://meyerweb.com/eric/tools/css/reset/ 
-   v2.0 | 20110126
-   License: none (public domain)
-*/
+import { createGlobalStyle } from 'styled-components'
+
+export const GlobalStyle = createGlobalStyle`
 
 * {
   box-sizing: border-box;
@@ -32,7 +31,6 @@ html, body {
   font-family: Arial, Helvetica, sans-serif;
 }
 
-/* HTML5 display-role reset for older browsers */
 article, aside, details, figcaption, figure,
 footer, header, hgroup, menu, nav, section {
   display: block;
@@ -58,4 +56,4 @@ q:before, q:after {
 
 table {
   border-spacing: 0;
-}
+}`

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import './index.css'
 import './utils/i18next'
 import App from './App'
 


### PR DESCRIPTION
#221 - Transformar index.css em styled-components
====
  
### 🆙 CHANGELOG

- No caminho src foi retirado o arquivo index.css que foge do padrão de projeto
- No mesmo caminho foi criado globalStyles.js que possui um componente global para a realização das definições de estilo
- No arquivo App.js no mesmo caminho foi integrado o componente global ao sistema

## ⚠️ Me certifico que:

- [ ] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [ ] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [ ] Solicitei **code review** para 2 pessoas
- [ ] Solicitei **QA** para 2 pessoas
- [ ] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:

- [x] Fazer clone da branch 221/Transformar-index-em-styled 
- [x] Abrir a aplicação de forma normal
- [x] Verificar a existência do componente globalStyles.js
- [x] Verificar se a aplicação abre de forma natural e mantém os padrões de estilo antes estabelecidos
- [x] Aplicação não deve conter nenhum erro, warning ou console.log
- [x] Alteração proposta no card foi implementada
