### PR TITLE
198 - Inconsistência do botão avaliar

### DIFF
--- a/src/pages/evaluation/index.js
+++ b/src/pages/evaluation/index.js
@@ -17,11 +17,14 @@ const EvaluationChallenge = () => {
 
   const exerciseId = window.location.pathname.split('/')[2]
 
+  const hasExerciseType = ({ exerciseType }) => !exerciseType
+
   useEffect(() => {
     client.get(`/exercise/${exerciseId}`)
       .then(res => (res.data))
       .then(res => {
         setExercise(res.exercise)
+        setDisableEvaluationButton(hasExerciseType(res.exercise))
       })
       .catch(err => {
         console.log(err)
@@ -44,7 +47,10 @@ const EvaluationChallenge = () => {
           <h1>{`${t('evaluation.title')} ${exercise.name}`}</h1>
         </div>
         <div key={exercise.id}>
-          <Header setDisableEvaluationButton={setDisableEvaluationButton} defaultType={exercise.exerciseType}/>
+          <Header
+            setDisableEvaluationButton={setDisableEvaluationButton}
+            defaultType={exercise.exerciseType}
+          />
 
           <Download>
             <Anchor href={exerciseStatement} target='_blank' rel='noreferrer'>
@@ -58,7 +64,12 @@ const EvaluationChallenge = () => {
           <ContainerButtons>
 
             <DefaultButton text={t('evaluation.cancel')} onClick={handleCancel} />
-            <Modal className={'primary'} text={t('evaluation.evaluate')} title={`${t('evaluation.title')} ${exercise.name}`} disabled={disableEvaluationButton} >
+            <Modal
+              className={'primary'}
+              text={t('evaluation.evaluate')}
+              title={`${t('evaluation.title')} ${exercise.name}`}
+              disabled={disableEvaluationButton}
+            >
 
               <Score exercise={exercise} />
 


### PR DESCRIPTION
…dev @JeanCastilhos2

#198 - Inconsistência do botão avaliar
====
  
### 🆙 CHANGELOG

- No arquivo index.js no caminho `src/pages/evaluation` foi criada uma função chamada hasExerciseType que recebe como parâmetro um exercício e  pega apenas o seu desestruturado. Ela retorna true ou false pela verificação
- No mesmo arquivo, foi chamada essa função dentro do useEffect, para validar o exercício recebido pelo back-end
- Caso o exercício possua um tipo já definido, o botão de avaliação ficará habilitado para utilização, caso contrário, ficará desabilitado.

## ⚠️ Me certifico que:

- [ ] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [ ] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [ ] Solicitei **code review** para 2 pessoas
- [ ] Solicitei **QA** para 2 pessoas
- [ ] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:


- [x] Fazer clone da branch no ambiente local
- [x] Executar a aplicação
- [x] Realizar login com um usuário local
- [x] Acessar a pagina de processos seletivos
- [x] Acessar um processo com exercícios inseridos
- [x] Verificar se os tipos dos desafios estão aparecendo na coluna de tipo (Não definido, frontend, backend e fullstack)
- [x] Acessar um desafio não definido, modificar o seu tipo e verificar se foi salvo
- [x] Acessar um desafio definido e verificar se o tipo está presente
- [x] Acessar um desafio definido, modificar o seu tipo e verificar se a mudança foi realizada
- [x] Verificar se em desafios sem tipos definidos se o botão avaliar está desabilitado
- [x] Verificar se em desafios com tipos definidos se o botão avaliar está habilitado
- [x] Aplicação não deve conter nenhum erro, warning ou console.log
- [x] Alteração proposta no card foi implementada
