### PR TITLE
fix(components/modal): adicionando z-index para as modais

### DIFF
--- a/src/components/modal/style.js
+++ b/src/components/modal/style.js
@@ -2,6 +2,7 @@ import style from 'styled-components'
 
 export const Container = style.div`
   position: fixed;
+  z-index: 9999;
   left: 0;
   top: 0;
   right: 0;


### PR DESCRIPTION

#217 - BUG: Paginação sobrepõe as modais
====
  
### 🆙 CHANGELOG

- Adicionado "z-index" nas modais.

## ⚠️ Me certifico que:

- [x] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [x] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [x] Solicitei **code review** para 2 pessoas
- [ ] Solicitei **QA** para 2 pessoas
- [ ] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:

*Esses passos são apenas exemplos*

- [x] Entre na branch: #217 
- [x] Rodar a aplicação local.
- [x] Logar na aplicação como administradora.
- [x] Acesse listagem de mentoras avaliadoras
- [x] Clique no botão editar e veja se os números da paginação está sobrepondo a modal de editar.
- [x] Aplicação não deve conter nenhum erro, warning ou console.log
- [x] Alteração proposta no card foi implementada
